### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :find_item, only: [:edit, :update]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :find_item, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 
 
 end


### PR DESCRIPTION
# What
商品削除機能の実装

# why
出品したユーザー本人が商品出品の取り消しができるようにするため

GyazoGIF
*[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/753e4769bff829fd0ad30b6508c42470)


商品削除機能の初回コードレビューです。
動画の指示がなかったためありませんが、ログインしている出品者以外のユーザーが商品を削除しようとしても、トップページへ遷移することを確認しております。
確認、指導をどうぞよろしくお願いします。